### PR TITLE
Added leaveOpenAfterClose parameter

### DIFF
--- a/Samples/Program.cs
+++ b/Samples/Program.cs
@@ -33,6 +33,19 @@ namespace Samples
             using (var file = new FileStream("sample_frozen3.xlsx", FileMode.Create))
             using (var writer = new ExcelSpreadsheetWriter(file, System.IO.Compression.CompressionLevel.Optimal))
                 PopulateData(writer, new FrozenPaneState { Column = 2, Row = 1 });
+
+            using (var memoryStream = new MemoryStream())
+            using (var writer =
+                new ExcelSpreadsheetWriter(memoryStream, System.IO.Compression.CompressionLevel.Optimal, true))
+            {
+                PopulateData(writer, new FrozenPaneState { Column = 4, Row = 1 });
+
+                memoryStream.Position = 0;
+                using(var file = new FileStream("sample_frozen_memorystream4.xlsx", FileMode.Create))
+                    memoryStream.CopyTo(file);
+            }
+                
+
         }
 
         static void PopulateData(SpreadsheetWriter writer, FrozenPaneState? sheet1Pane = null)

--- a/SpreadsheetStreams/Code/Core/StreamWritePackage.cs
+++ b/SpreadsheetStreams/Code/Core/StreamWritePackage.cs
@@ -14,9 +14,9 @@ namespace SpreadsheetStreams
         private List<ContentType> _ContentTypes = new List<ContentType>();
         private Dictionary<string, List<Relationship>> _PartRelationships = new Dictionary<string, List<Relationship>>();
 
-        internal PackageWriteStream(Stream outputStream, bool leaveOpenAfterClose)
+        internal PackageWriteStream(Stream outputStream, bool leaveOpen)
         {
-            _ZipArchive = new ZipArchive(outputStream, ZipArchiveMode.Create, leaveOpenAfterClose);
+            _ZipArchive = new ZipArchive(outputStream, ZipArchiveMode.Create, leaveOpen);
         }
 
         #region IDisposable

--- a/SpreadsheetStreams/Code/Core/StreamWritePackage.cs
+++ b/SpreadsheetStreams/Code/Core/StreamWritePackage.cs
@@ -14,9 +14,9 @@ namespace SpreadsheetStreams
         private List<ContentType> _ContentTypes = new List<ContentType>();
         private Dictionary<string, List<Relationship>> _PartRelationships = new Dictionary<string, List<Relationship>>();
 
-        internal PackageWriteStream(Stream outputStream)
+        internal PackageWriteStream(Stream outputStream, bool leaveOpenAfterClose)
         {
-            _ZipArchive = new ZipArchive(outputStream, ZipArchiveMode.Create);
+            _ZipArchive = new ZipArchive(outputStream, ZipArchiveMode.Create, leaveOpenAfterClose);
         }
 
         #region IDisposable

--- a/SpreadsheetStreams/Code/Excel/ExcelSpreadsheetWriter.cs
+++ b/SpreadsheetStreams/Code/Excel/ExcelSpreadsheetWriter.cs
@@ -14,7 +14,7 @@ namespace SpreadsheetStreams
     {
         #region Constructors
 
-        public ExcelSpreadsheetWriter(Stream outputStream, CompressionLevel compressionLevel = CompressionLevel.Fastest)
+        public ExcelSpreadsheetWriter(Stream outputStream, CompressionLevel compressionLevel = CompressionLevel.Fastest, bool leaveOpenAfterFinish = false)
             : base(outputStream ?? new MemoryStream())
         {
             if (outputStream.GetType().FullName == "System.Web.HttpResponseStream")
@@ -22,7 +22,7 @@ namespace SpreadsheetStreams
                 outputStream = new WriteStreamWrapper(outputStream);
             }
 
-            _Package = new PackageWriteStream(outputStream);
+            _Package = new PackageWriteStream(outputStream, leaveOpenAfterFinish);
 
             _CompressionLevel = compressionLevel;
         }

--- a/SpreadsheetStreams/Code/Excel/ExcelSpreadsheetWriter.cs
+++ b/SpreadsheetStreams/Code/Excel/ExcelSpreadsheetWriter.cs
@@ -14,7 +14,7 @@ namespace SpreadsheetStreams
     {
         #region Constructors
 
-        public ExcelSpreadsheetWriter(Stream outputStream, CompressionLevel compressionLevel = CompressionLevel.Fastest, bool leaveOpenAfterFinish = false)
+        public ExcelSpreadsheetWriter(Stream outputStream, CompressionLevel compressionLevel = CompressionLevel.Fastest, bool leaveOpen = false)
             : base(outputStream ?? new MemoryStream())
         {
             if (outputStream.GetType().FullName == "System.Web.HttpResponseStream")
@@ -22,7 +22,7 @@ namespace SpreadsheetStreams
                 outputStream = new WriteStreamWrapper(outputStream);
             }
 
-            _Package = new PackageWriteStream(outputStream, leaveOpenAfterFinish);
+            _Package = new PackageWriteStream(outputStream, leaveOpen);
 
             _CompressionLevel = compressionLevel;
         }


### PR DESCRIPTION
Allow to not close passed `Stream` after calling `Finish()` method on `ExcelSpreadSheetWriter`

fixes #2 