### PR TITLE
fix cell addressing and performance

### DIFF
--- a/SpreadsheetStreams.sln
+++ b/SpreadsheetStreams.sln
@@ -1,11 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.572
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples", "Samples\Samples.csproj", "{BD3E902F-AB43-4BB7-A5FB-3D57BA469240}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpreadsheetStreams", "SpreadsheetStreams\SpreadsheetStreams.csproj", "{34B2EAC9-F35A-48AF-A89E-C13D76451023}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{5F00C8FD-053B-44FF-841F-F2CD03049F71}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpreadsheetStreams.ExcelTests", "Tests\SpreadsheetStreams.ExcelTests\SpreadsheetStreams.ExcelTests.csproj", "{F332665D-87A3-44D0-999E-97EE25DDF71C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,9 +25,16 @@ Global
 		{34B2EAC9-F35A-48AF-A89E-C13D76451023}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{34B2EAC9-F35A-48AF-A89E-C13D76451023}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{34B2EAC9-F35A-48AF-A89E-C13D76451023}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F332665D-87A3-44D0-999E-97EE25DDF71C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F332665D-87A3-44D0-999E-97EE25DDF71C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F332665D-87A3-44D0-999E-97EE25DDF71C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F332665D-87A3-44D0-999E-97EE25DDF71C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F332665D-87A3-44D0-999E-97EE25DDF71C} = {5F00C8FD-053B-44FF-841F-F2CD03049F71}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C27CB6A4-5719-411D-93F7-0E3D42FFC9A1}

--- a/SpreadsheetStreams/Code/Excel/ExcelSpreadsheetWriter.cs
+++ b/SpreadsheetStreams/Code/Excel/ExcelSpreadsheetWriter.cs
@@ -629,26 +629,17 @@ namespace SpreadsheetStreams
 
             }
 
-            int a = 0, b = 0, c = 0;
-            var address = "";
-            for (int i = 0; i < columnNumber; i++)
+            const int @base = 26;
+            columnNumber -= 1;
+            
+            var address = string.Empty; 
+            
+            do 
             {
-                if (a > 25)
-                {
-                    b++;
-                    a = 0;
-                }
-                if (b > 25)
-                {
-                    c++;
-                    b = 0;
-                }
-                a++;
-            }
-
-            if (c > 0) { address += ((char)(c + 64)); }
-            if (b > 0) { address += ((char)(b + 64)); }
-            address += ((char)(a + 64));
+                address = Convert.ToChar('A' + columnNumber % @base) + address;
+                columnNumber = columnNumber / @base - 1; 
+            } 
+            while (columnNumber >= 0);
 
             return address;
         }

--- a/Tests/SpreadsheetStreams.ExcelTests/CellAddressingTests.cs
+++ b/Tests/SpreadsheetStreams.ExcelTests/CellAddressingTests.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+
+namespace SpreadsheetStreams.ExcelTests
+{
+    public class CellAddressingTests
+    {
+        [Fact]
+        public void WhenColumnNumberIsBelowMinimum_ShouldThrowException()
+        {
+            Assert.Throws<Exception>(() =>
+            {
+                var minimum = ExcelSpreadsheetWriter.MIN_COLUMN_NUMBER - 1;
+                var address = ExcelSpreadsheetWriter.ConvertColumnAddress(minimum);
+            });
+        }
+
+        [Fact]
+        public void WhenColumnNumberIsOverMaximum_ShouldThrowException()
+        {
+            Assert.Throws<Exception>(() =>
+            {
+                var maximum = ExcelSpreadsheetWriter.MAX_COLUMN_NUMBER + 1;
+                var address = ExcelSpreadsheetWriter.ConvertColumnAddress(maximum);
+            });
+        }
+
+        [Theory]
+        [InlineData(1, "A")]
+        [InlineData(27, "AA")]
+        [InlineData(703, "AAA")]
+        [InlineData(16384, "XFD")]
+        public void TestCellAddressing(int columnNumber, string expectedAddress)
+        {
+            var address = ExcelSpreadsheetWriter.ConvertColumnAddress(columnNumber);
+
+            Assert.Equal(expectedAddress, address);
+        }
+    }
+}

--- a/Tests/SpreadsheetStreams.ExcelTests/SpreadsheetStreams.ExcelTests.csproj
+++ b/Tests/SpreadsheetStreams.ExcelTests/SpreadsheetStreams.ExcelTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SpreadsheetStreams\SpreadsheetStreams.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/SpreadsheetStreams.ExcelTests/Usings.cs
+++ b/Tests/SpreadsheetStreams.ExcelTests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
The current cell address algorithm is generating wrong results.

When the last used address is YZ the next one would be AA, which is wrong.

Furthermore, the algorithm becomes very slow if large numbers of cells are used.