### PR TITLE
Rows and cells skipping

### DIFF
--- a/SpreadsheetStreams/Code/Excel/ExcelSpreadsheetWriter.cs
+++ b/SpreadsheetStreams/Code/Excel/ExcelSpreadsheetWriter.cs
@@ -1057,6 +1057,11 @@ namespace SpreadsheetStreams
 
         public void SkipRows(int count)
         {
+            if (!_ShouldEndWorksheet)
+            {
+                throw new InvalidOperationException("Adding new rows is not allowed at this time. Please call NewWorksheet(...) first.");
+            }
+
             WritePendingBeginWorksheet();
             WritePendingEndRow();
 

--- a/SpreadsheetStreams/Code/Excel/ExcelSpreadsheetWriter.cs
+++ b/SpreadsheetStreams/Code/Excel/ExcelSpreadsheetWriter.cs
@@ -1059,6 +1059,20 @@ namespace SpreadsheetStreams
             _ShouldEndRow = true;
         }
 
+        public void SkipRow()
+        {
+            SkipRows(1);
+        }
+
+        public void SkipRows(int count)
+        {
+            WritePendingBeginWorksheet();
+            WritePendingEndRow();
+
+            _RowCount += count;
+            _CellCount = 0;
+        }
+
         private void WriteCellHeader(int cellIndex, int rowIndex, bool closed, string type, Style style = null)
         {
             _CurrentWorksheetPartWriter.Write($"<c r=\"{ConvertColumnAddress(cellIndex)}{rowIndex}\"");
@@ -1097,6 +1111,16 @@ namespace SpreadsheetStreams
         #endregion
 
         #region SpreadsheetWriter - Cell methods
+
+        public void SkipCell()
+        {
+            SkipCells(1);
+        }
+
+        public void SkipCells(int count)
+        {
+            _CellCount += count;
+        }
 
         public override void AddCell(string data, Style style = null, int horzCellCount = 0, int vertCellCount = 0)
         {

--- a/SpreadsheetStreams/SpreadsheetStreams.csproj
+++ b/SpreadsheetStreams/SpreadsheetStreams.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SpreadsheetStreams</RootNamespace>
-    <AssemblyName>SpreadsheetStreams.net</AssemblyName>
+    <AssemblyName>Thunders.SpreadsheetStreams.net</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>
 	<LangVersion>8.0</LangVersion>
     <FileAlignment>512</FileAlignment>
@@ -43,7 +43,7 @@
     <PackageProjectUrl></PackageProjectUrl>
     <RepositoryUrl>https://github.com/danielgindi/SpreadsheetStreams.net</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/danielgindi/SpreadsheetStreams.net/blob/master/LICENSE</PackageLicenseUrl>
-    <Version>1.0.19</Version>
+    <Version>1.0.20</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/SpreadsheetStreams/SpreadsheetStreams.csproj
+++ b/SpreadsheetStreams/SpreadsheetStreams.csproj
@@ -43,7 +43,7 @@
     <PackageProjectUrl></PackageProjectUrl>
     <RepositoryUrl>https://github.com/danielgindi/SpreadsheetStreams.net</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/danielgindi/SpreadsheetStreams.net/blob/master/LICENSE</PackageLicenseUrl>
-    <Version>1.1.0</Version>
+    <Version>1.0.20</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/SpreadsheetStreams/SpreadsheetStreams.csproj
+++ b/SpreadsheetStreams/SpreadsheetStreams.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SpreadsheetStreams</RootNamespace>
-    <AssemblyName>Thunders.SpreadsheetStreams.net</AssemblyName>
+    <AssemblyName>SpreadsheetStreams.net</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>
 	<LangVersion>8.0</LangVersion>
     <FileAlignment>512</FileAlignment>

--- a/SpreadsheetStreams/SpreadsheetStreams.csproj
+++ b/SpreadsheetStreams/SpreadsheetStreams.csproj
@@ -43,7 +43,7 @@
     <PackageProjectUrl></PackageProjectUrl>
     <RepositoryUrl>https://github.com/danielgindi/SpreadsheetStreams.net</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/danielgindi/SpreadsheetStreams.net/blob/master/LICENSE</PackageLicenseUrl>
-    <Version>1.0.20</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/Tests/SpreadsheetStreams.ExcelTests/CellAddressingTests.cs
+++ b/Tests/SpreadsheetStreams.ExcelTests/CellAddressingTests.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 namespace SpreadsheetStreams.ExcelTests
 {
     public class CellAddressingTests

--- a/Tests/SpreadsheetStreams.ExcelTests/CellSkippingTests.cs
+++ b/Tests/SpreadsheetStreams.ExcelTests/CellSkippingTests.cs
@@ -1,0 +1,43 @@
+﻿using System.IO.Compression;
+using System.Xml.Linq;
+
+namespace SpreadsheetStreams.ExcelTests
+{
+    public class CellSkippingTests
+    {
+        [Fact]
+        public void TestSkippingCells()
+        {
+            using var ms = new MemoryStream();
+            var writer = new ExcelSpreadsheetWriter(ms, leaveOpen: true);
+
+            writer.NewWorksheet(new WorksheetInfo()
+            {
+                Name = "Test Worksheet"
+            });
+
+            writer.AddRow();
+            writer.AddCell("Test Cell");
+
+            writer.SkipCells(5);
+
+            writer.AddCell("New Cell");
+
+            writer.Finish();
+
+            ms.Position = 0;
+            using var archive = new ZipArchive(ms, ZipArchiveMode.Read, true);
+
+            var sheetEntry = archive.GetEntry("xl/worksheets/sheet1.xml")!;
+            using var sheetStream = sheetEntry.Open();
+
+            var doc = XDocument.Load(sheetStream);
+            var rootNamespace = doc.Root!.Name.Namespace;
+
+            var cell = doc.Descendants(rootNamespace! + "c")
+                .LastOrDefault();
+
+            Assert.Equal("G1", cell?.Attribute("r")?.Value);
+        }
+    }
+}

--- a/Tests/SpreadsheetStreams.ExcelTests/RowSkippingTests.cs
+++ b/Tests/SpreadsheetStreams.ExcelTests/RowSkippingTests.cs
@@ -1,0 +1,89 @@
+﻿using System.IO.Compression;
+using System.Xml.Linq;
+
+namespace SpreadsheetStreams.ExcelTests
+{
+    public class RowSkippingTests
+    {
+        [Fact]
+        public void WhenSkippingRowsWithoutWorksheet_ShouldThrow()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                using var ms = new MemoryStream();
+                var writer = new ExcelSpreadsheetWriter(ms);
+
+                writer.SkipRow();
+            });
+        }
+
+        [Fact]
+        public void TestSkippingRowsOnBeginning()
+        {
+            using var ms = new MemoryStream();
+            var writer = new ExcelSpreadsheetWriter(ms, leaveOpen: true);
+
+            writer.NewWorksheet(new WorksheetInfo()
+            {
+                Name = "Test Worksheet"
+            });
+
+            writer.SkipRows(5);
+
+            writer.AddRow();
+            writer.AddCell("Test Cell");
+
+            writer.Finish();
+
+            ms.Position = 0;
+            using var archive = new ZipArchive(ms, ZipArchiveMode.Read, true);
+
+            var sheetEntry = archive.GetEntry("xl/worksheets/sheet1.xml")!;
+            using var sheetStream = sheetEntry.Open();
+
+            var doc = XDocument.Load(sheetStream);
+            var rootNamespace = doc.Root!.Name.Namespace;
+
+            var row = doc.Descendants(rootNamespace! + "row")
+                .FirstOrDefault();
+
+            Assert.Equal("6", row?.Attribute("r")?.Value);
+        }
+
+        [Fact]
+        public void TestSkippingRowsAfterExistingRow()
+        {
+            using var ms = new MemoryStream();
+            var writer = new ExcelSpreadsheetWriter(ms, leaveOpen: true);
+
+            writer.NewWorksheet(new WorksheetInfo()
+            {
+                Name = "Test Worksheet"
+            });
+
+            writer.AddRow();
+            writer.AddCell("Test Cell");
+
+            writer.SkipRows(5);
+
+            writer.AddRow();
+            writer.AddCell("Test Cell");
+
+            writer.Finish();
+
+            ms.Position = 0;
+            using var archive = new ZipArchive(ms, ZipArchiveMode.Read, true);
+
+            var sheetEntry = archive.GetEntry("xl/worksheets/sheet1.xml")!;
+            using var sheetStream = sheetEntry.Open();
+
+            var doc = XDocument.Load(sheetStream);
+            var rootNamespace = doc.Root!.Name.Namespace;
+
+            var row = doc.Descendants(rootNamespace! + "row")
+                .LastOrDefault();
+
+            Assert.Equal("7", row?.Attribute("r")?.Value);
+        }
+    }
+}


### PR DESCRIPTION
To skip rows and cells the only available way is to add a blank cell or empty row.

This PR allows skipping rows and cells as it's still a valid Excel XML.